### PR TITLE
Styled pre to show response vertically

### DIFF
--- a/devtools/output-styles.js
+++ b/devtools/output-styles.js
@@ -42,7 +42,7 @@ export default `
   }
 
   .response pre {
-    max-height: 500px;
-    overflow: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
   }
 `;


### PR DESCRIPTION
Styled the pre so the response is displayed vertically instead of horizontal. 

![bilde](https://user-images.githubusercontent.com/5339228/70889613-4f7f4700-1fe3-11ea-8108-81c8ee72e74b.png)
